### PR TITLE
feat: GEO RNA-seq preflight in Streamlit (submission_ready, FAIL/WARN…

### DIFF
--- a/demos/bulk_demo/files.tsv
+++ b/demos/bulk_demo/files.tsv
@@ -1,0 +1,4 @@
+sample_id	layout	filename
+S1	        PAIRED	S1_R1.fastq.gz
+S1	        PAIRED	S1_R2.fastq.gz
+S999	    PAIRED	S999_R1.fastq.gz

--- a/demos/bulk_demo/samples.tsv
+++ b/demos/bulk_demo/samples.tsv
@@ -1,0 +1,3 @@
+sample_id	sample_title	organism	library_strategy	molecule	instrument_model	tissue	cell_line	cell_type	collection_date
+S1	        liver sample	human	RNA-Seq	total RNA	Illumina NovaSeq	liver			10/3/25
+S2	        ???	        human	RNA-Seq	total RNA	Illumina NovaSeq				2025-10-02

--- a/fairy/core/services/validator.py
+++ b/fairy/core/services/validator.py
@@ -1,33 +1,171 @@
 # fairy/core/services/validator.py
-from dataclasses import dataclass
-from typing import List, Dict, Protocol
+# Responsibilities:
+# - Expose validate_csv(...) for the generic CSV workflow (older path)
+# - Expose run_rulepack(...) for GEO RNA-seq preflight
+#   (rulepack: fairy/rulepacks/GEO-SEQ-BULK/v0_1_0.json)
+#
+# run_rulepack:
+#   - loads rulepack
+#   - loads samples.tsv and files.tsv
+#   - calls helper checks in validators/rna.py
+#   - maps WarningItem -> FAIRy Findings with code / severity / where / why / how_to_fix
+#   - builds Attestation
+#   - returns {attestation, findings}
 
-@dataclass
-class WarningItem:
-    column: str
-    check: str
-    failure: str
-    index: int
+from __future__ import annotations
 
-@dataclass
-class Meta:
-    n_rows: int
-    n_cols: int
-    fields_validated: List[str]
-    warnings: List[WarningItem]
+from pathlib import Path
+import json
+from typing import List, Dict, Any
+import pandas as pd
 
-class Validator(Protocol):
-    name: str
-    version: str
-    def validate(self, path: str) -> Meta: ...
+# pull shared types/utilities
+from ..validation_api import (
+    WarningItem,
+    Finding,
+    Attestation,
+    Report,
+    now_utc_iso,
+    validate_csv as _core_validate_csv,  # <-- NEW: import the canonical validate_csv
+)
 
-# registry
-_REGISTRY: Dict[str, Validator] = {}
+from ..validators import rna  # to call check_* helpers
 
-def register(kind: str, validator: Validator):
-    _REGISTRY[kind] = validator
 
-def validate_csv(path: str, kind: str = "rna") -> Meta:
-    # fallback to generic if kind not found
-    v = _REGISTRY.get(kind) or _REGISTRY["generic"]
-    return v.validate(path)
+# --- NEW: bridge function so legacy code (process_csv) still works ---
+def validate_csv(path: str, kind: str = "rna"):
+    """
+    Thin wrapper that delegates to core.validation_api.validate_csv.
+
+    We keep this here because process_csv.py imports
+    `from fairy.core.services.validator import validate_csv`.
+
+    Returning whatever validation_api.validate_csv returns
+    (a Meta object).
+    """
+    return _core_validate_csv(path, kind=kind)
+
+
+def _map_severity(internal: str) -> str:
+    # "error" -> "FAIL", "warning" -> "WARN"
+    return "FAIL" if internal.lower() == "error" else "WARN"
+
+
+def _where_from_issue(issue: WarningItem, fallback_where: str) -> str:
+    bits: List[str] = []
+    if issue.row is not None and issue.row >= 0:
+        bits.append(f"row {issue.row}")
+    if issue.column:
+        bits.append(f"column '{issue.column}'")
+    if bits:
+        return ", ".join(bits)
+    return fallback_where
+
+
+def run_rulepack(
+    rulepack_path: Path,
+    samples_path: Path,
+    files_path: Path,
+    fairy_version: str = "0.2.0",
+) -> dict:
+    # 1. load rulepack JSON
+    pack = json.loads(Path(rulepack_path).read_text())
+
+    # 2. load dataframes
+    samples_df = pd.read_csv(samples_path, sep="\t", dtype=str).fillna("")
+    files_df = pd.read_csv(files_path, sep="\t", dtype=str).fillna("")
+
+    all_findings: List[dict] = []
+
+    for rule in pack["rules"]:
+        spec = rule["check"]
+        ctype = spec["type"]
+
+        # dispatch to the right helper in rna.py
+        if ctype == "require_columns":
+            required_cols = spec.get("required_columns", [])
+            warning_items = rna.check_required_columns(samples_df, required_cols)
+
+        elif ctype == "at_least_one_nonempty_per_row":
+            # spec["column_groups"] is like [["tissue","cell_line","cell_type"]]
+            column_groups = spec.get("column_groups", [])
+            group0 = column_groups[0] if column_groups else []
+            warning_items = rna.check_bio_context(samples_df, group0)
+
+        elif ctype == "id_crosscheck":
+            # left_key is the sample ID key in samples.tsv
+            left_key = spec.get("left_key", "sample_id")
+            warning_items = rna.check_id_crossmatch(
+                samples_df,
+                files_df,
+                samples_key=left_key,
+            )
+
+        elif ctype == "paired_end_complete":
+            # be defensive and default sanely
+            warning_items = rna.check_paired_end_complete(
+                files_df,
+                samples_key=spec.get("samples_key", "sample_id"),
+                layout_col=spec.get("layout_column", "layout"),
+                paired_value=spec.get("layout_value_for_paired", "PAIRED"),
+                file_col=spec.get("file_column", "filename"),
+                r1_pattern=spec.get("r1_pattern", r"_R1"),
+                r2_pattern=spec.get("r2_pattern", r"_R2"),
+            )
+
+        elif ctype == "dates_are_iso8601":
+            date_cols = spec.get("columns", [])
+            warning_items = rna.check_dates_iso8601(samples_df, date_cols)
+
+        elif ctype == "processed_data_present":
+            warning_items = rna.check_processed_data_present(
+                files_df,
+                samples_key=spec.get("samples_key", "sample_id"),
+                raw_file_glob=spec.get("raw_file_glob", ".fastq"),
+                processed_globs=spec.get(
+                    "processed_glob_candidates",
+                    [".counts", ".quant", ".gene_counts"],
+                ),
+            )
+
+        else:
+            warning_items = []
+
+        # convert WarningItem -> final FAIRy "finding"
+        for w in warning_items:
+            mapped_sev = _map_severity(w.severity)
+            finding = {
+                "code": rule["code"],
+                "severity": mapped_sev,
+                "where": _where_from_issue(w, rule["where"]),
+                "why": rule["why"],
+                "how_to_fix": rule["how_to_fix"],
+                "details": {
+                    "kind": w.kind,
+                    "message": w.message,
+                    "hint": w.hint,
+                    "row": w.row,
+                    "column": w.column,
+                },
+            }
+            all_findings.append(finding)
+
+    fail_count = sum(1 for f in all_findings if f["severity"] == "FAIL")
+    warn_count = sum(1 for f in all_findings if f["severity"] == "WARN")
+
+    attestation = {
+        "rulepack_id": pack.get("rulepack_id", "UNKNOWN_RULEPACK"),
+        "rulepack_version": pack.get("rulepack_version", "0.0.0"),
+        "fairy_version": fairy_version,
+        "run_at_utc": now_utc_iso(),
+        "submission_ready": (fail_count == 0),
+        "fail_count": fail_count,
+        "warn_count": warn_count,
+    }
+
+    report = {
+        "attestation": attestation,
+        "findings": all_findings,
+    }
+
+    return report

--- a/fairy/core/validation_api.py
+++ b/fairy/core/validation_api.py
@@ -1,0 +1,84 @@
+# fairy/core/validation_api.py
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Dict, Protocol, Any, Optional
+from datetime import datetime, timezone
+
+# --- Basic types you already use ---
+
+@dataclass
+class WarningItem:
+    # what column/field the problem is about (if any)
+    column: Optional[str]
+    # machine-ish category of check, like "missing_column"
+    kind: str
+    # human summary of what failed ("Required column 'sample_id' is missing")
+    message: str
+    # "error" or "warning"
+    severity: str
+    # row index in the table if applicable (or -1 / None for header-level problems)
+    row: Optional[int] = None
+    # optional hint for how to fix
+    hint: Optional[str] = None
+
+@dataclass
+class Meta:
+    n_rows: int
+    n_cols: int
+    fields_validated: List[str]
+    warnings: List[WarningItem]
+
+# --- Validator interface + registry ---
+
+class Validator(Protocol):
+    name: str
+    version: str
+    def validate(self, path: str) -> Meta:
+        ...
+
+_VALIDATORS: Dict[str, Validator] = {}
+
+def register(name: str, validator: Validator):
+    _VALIDATORS[name] = validator
+
+def get_validator(kind: str) -> Optional[Validator]:
+    return _VALIDATORS.get(kind)
+
+def validate_csv(path: str, kind: str = "rna") -> Meta:
+    v = _VALIDATORS.get(kind) or _VALIDATORS.get("generic")
+    if v is None:
+        raise RuntimeError(f"No validator registered for kind='{kind}' or 'generic'")
+    return v.validate(path)
+
+# --- Richer FAIRy finding types we'll add soon ---
+
+@dataclass
+class Finding:
+    code: str            # e.g. "GEO.REQ.MISSING_FIELD"
+    severity: str        # "FAIL" | "WARN"
+    where: str
+    why: str
+    how_to_fix: str
+    details: Dict[str, Any]
+
+@dataclass
+class Attestation:
+    rulepack_id: str
+    rulepack_version: str
+    fairy_version: str
+    run_at_utc: str
+    submission_ready: bool
+    fail_count: int
+    warn_count: int
+
+@dataclass
+class Report:
+    attestation: Attestation
+    findings: List[Finding]
+
+def now_utc_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+

--- a/fairy/core/validators/generic.py
+++ b/fairy/core/validators/generic.py
@@ -1,15 +1,23 @@
 # fairy/core/validators/generic.py
+
 import pandas as pd
-from ..services.validator import Meta, WarningItem, register
+from ..validation_api import Meta, register
 
 class GenericCSVValidator:
     name = "generic"
     version = "0.1.0"
+
     def validate(self, path: str) -> Meta:
         df = pd.read_csv(path)
-        # no domain rules; just counts + discovered fields
-        fields = list(df.columns)[:50]  # cap
-        return Meta(n_rows=int(df.shape[0]), n_cols=int(df.shape[1]),
-                    fields_validated=fields, warnings=[])
+
+        # No domain rules; just summarize the shape and the first ~50 columns
+        fields = list(df.columns)[:50]
+
+        return Meta(
+            n_rows=int(df.shape[0]),
+            n_cols=int(df.shape[1]),
+            fields_validated=fields,
+            warnings=[],
+        )
 
 register("generic", GenericCSVValidator())

--- a/fairy/core/validators/rna.py
+++ b/fairy/core/validators/rna.py
@@ -1,37 +1,342 @@
-# fairy/core/validators/rna.py
+import re
+from typing import List, Dict, Set
 import pandas as pd
-from ..services.validator import Meta, WarningItem, register
+
+from ..validation_api import Meta, WarningItem, register
+
 
 class RNAValidator:
     name = "rna"
     version = "0.1.0"
+
     REQUIRED = ["sample_id"]
-    OPTIONAL = ["collection_date", "tissue", "read_length"]
+    OPTIONAL = ["collection_date", "tissue", "cell_line", "cell_type", "read_length"]
 
     def validate(self, path: str) -> Meta:
         df = pd.read_csv(path)
-        warns: List[WarningItem] = []
 
-        # required column checks
-        for col in self.REQUIRED:
-            if col not in df.columns:
-                warns.append(WarningItem(col, "required", "missing column", -1))
-
-        # not-null sample_id
-        if "sample_id" in df.columns:
-            bad = df["sample_id"].isna()
-            for i in df.index[bad]:
-                warns.append(WarningItem("sample_id","not_null","null value",int(i)))
-
-        # read_length ≥1
-        if "read_length" in df.columns:
-            rl = pd.to_numeric(df["read_length"], errors="coerce").fillna(-1)
-            for i in df.index[rl < 1]:
-                warns.append(WarningItem("read_length",">=1","non-positive or invalid",int(i)))
+        warnings: List[WarningItem] = []
+        warnings.extend(check_required_columns(df, self.REQUIRED))
+        warnings.extend(check_not_null(df, "sample_id"))
+        warnings.extend(check_read_length(df, "read_length"))
+        # we could also run check_dates_iso8601 here, etc.
 
         fields = [c for c in df.columns if c in set(self.REQUIRED + self.OPTIONAL)]
-        return Meta(n_rows=int(df.shape[0]), n_cols=int(df.shape[1]),
-                    fields_validated=sorted(fields), warnings=warns[:200])
 
-# register at import time
+        return Meta(
+            n_rows=int(df.shape[0]),
+            n_cols=int(df.shape[1]),
+            fields_validated=sorted(fields),
+            warnings=warnings[:200],
+        )
+
+
 register("rna", RNAValidator())
+
+
+#
+# === helpers used by 'validate' and 'preflight'
+#
+
+def check_required_columns(df: pd.DataFrame, required_cols: List[str]) -> List[WarningItem]:
+    """
+    Spec: rule['check']['type'] == 'require_columns'
+          rule['check']['required_columns'] = [...]
+    We FAIL (severity="error") if any required col is missing.
+    """
+    issues: List[WarningItem] = []
+    for col in required_cols:
+        if col not in df.columns:
+            issues.append(
+                WarningItem(
+                    column=col,
+                    kind="missing_column",
+                    message=f"Required column '{col}' is missing.",
+                    severity="error",
+                    row=None,
+                    hint="Add this column before submission.",
+                )
+            )
+    return issues
+
+
+def check_not_null(df: pd.DataFrame, col: str) -> List[WarningItem]:
+    """
+    Used in simple CSV validation, not directly by run_rulepack().
+    FAIL (severity='error') if a required field is blank/null.
+    """
+    issues: List[WarningItem] = []
+    if col in df.columns:
+        nullish = df[col].isna() | df[col].astype(str).str.strip().eq("")
+        for r in df.index[nullish]:
+            issues.append(
+                WarningItem(
+                    column=col,
+                    kind="missing_value",
+                    message=f"Missing value in required field '{col}'.",
+                    severity="error",
+                    row=int(r),
+                    hint="Fill this cell.",
+                )
+            )
+    return issues
+
+
+def check_read_length(df: pd.DataFrame, col: str) -> List[WarningItem]:
+    """
+    Just an example QC: read_length should be numeric >= 1.
+    We'll WARN (severity='warning') if not.
+    """
+    issues: List[WarningItem] = []
+    if col in df.columns:
+        rl = pd.to_numeric(df[col], errors="coerce").fillna(-1)
+        bad_mask = rl < 1
+        for r in df.index[bad_mask]:
+            issues.append(
+                WarningItem(
+                    column=col,
+                    kind="invalid_read_length",
+                    message="read_length must be >= 1",
+                    severity="warning",
+                    row=int(r),
+                    hint="Use an integer read length like 50, 75, 100...",
+                )
+            )
+    return issues
+
+
+#
+# === helpers only used by run_rulepack() / rulepack-driven checks
+#
+
+def check_bio_context(df: pd.DataFrame, biological_context_cols: List[str]) -> List[WarningItem]:
+    """
+    Spec: type == 'at_least_one_nonempty_per_row'
+          spec['column_groups'][0] = ["tissue", "cell_line", "cell_type", ...]
+    For each row in samples, at least ONE of those columns must be non-empty.
+    If no biological context at all => FAIL (severity='error').
+    """
+    issues: List[WarningItem] = []
+
+    for idx, row in df.iterrows():
+        has_any = False
+        for col in biological_context_cols:
+            if col in df.columns:
+                val = str(row.get(col, "")).strip()
+                if val != "":
+                    has_any = True
+                    break
+
+        if not has_any:
+            sid = row.get("sample_id", f"row_{idx}")
+            issues.append(
+                WarningItem(
+                    column=None,
+                    kind="bio_context_missing",
+                    message=f"Sample '{sid}' does not provide tissue/cell_line/cell_type.",
+                    severity="error",
+                    row=int(idx),
+                    hint="Fill at least one of: tissue, cell_line, or cell_type.",
+                )
+            )
+
+    return issues
+
+
+def check_id_crossmatch(
+    samples_df: pd.DataFrame,
+    files_df: pd.DataFrame,
+    *,
+    samples_key: str,
+) -> List[WarningItem]:
+    """
+    Spec: type == 'id_crosscheck'
+          spec['left_key'] -> passed in as samples_key
+
+    We enforce: every files_df[samples_key] must exist in samples_df[samples_key].
+    Missing or unknown sample_id => FAIL (severity='error').
+    """
+    issues: List[WarningItem] = []
+
+    # If the expected column doesn't exist in either frame, just bail cleanly
+    if samples_key not in samples_df.columns or samples_key not in files_df.columns:
+        return issues
+
+    # Build known IDs from samples.tsv
+    known_ids: Set[str] = set(
+        str(x).strip()
+        for x in samples_df[samples_key].fillna("")
+        if str(x).strip() != ""
+    )
+
+    # Check each row in files.tsv
+    for idx, row in files_df.iterrows():
+        sid = str(row.get(samples_key, "")).strip()
+        if sid == "":
+            issues.append(
+                WarningItem(
+                    column=samples_key,
+                    kind="file_missing_sample_id",
+                    message="Row in files.tsv has no sample_id.",
+                    severity="error",
+                    row=int(idx),
+                    hint="Each file row must name the sample_id it belongs to.",
+                )
+            )
+        elif sid not in known_ids:
+            issues.append(
+                WarningItem(
+                    column=samples_key,
+                    kind="file_unknown_sample_id",
+                    message=f"File references sample_id '{sid}' not found in samples.tsv.",
+                    severity="error",
+                    row=int(idx),
+                    hint="Fix sample_id or add that sample to samples.tsv.",
+                )
+            )
+
+    return issues
+
+
+def check_paired_end_complete(
+    files_df: pd.DataFrame,
+    *,
+    samples_key: str,
+    layout_col: str,
+    paired_value: str,
+    file_col: str,
+    r1_pattern: str,
+    r2_pattern: str,
+) -> List[WarningItem]:
+    """
+    Spec: type == 'paired_end_complete'
+          spec provides:
+            samples_key                e.g. "sample_id"
+            layout_column              e.g. "layout"
+            layout_value_for_paired    e.g. "PAIRED"
+            file_column                e.g. "filename"
+            r1_pattern                 e.g. "_R1"
+            r2_pattern                 e.g. "_R2"
+
+    Rule: for each paired sample (layout == paired_value),
+    we expect both an R1 and an R2 file for that sample.
+    Missing mate => FAIL.
+    """
+    issues: List[WarningItem] = []
+
+    rx_r1 = re.compile(r1_pattern)
+    rx_r2 = re.compile(r2_pattern)
+
+    # Filter just the paired rows first
+    paired_rows = files_df[
+        (files_df.get(layout_col, "").astype(str).str.upper() == paired_value.upper())
+    ]
+
+    # Group by sample id
+    for sid, group in paired_rows.groupby(samples_key):
+        if file_col not in group.columns:
+            continue
+
+        filenames = group[file_col].astype(str).tolist()
+
+        has_r1 = any(rx_r1.search(fn) for fn in filenames)
+        has_r2 = any(rx_r2.search(fn) for fn in filenames)
+
+        if not has_r1 or not has_r2:
+            first_idx = int(group.index[0]) if len(group.index) > 0 else None
+            issues.append(
+                WarningItem(
+                    column=file_col,
+                    kind="paired_end_incomplete",
+                    message=f"Paired-end sample '{sid}' is missing R1 or R2 FASTQ.",
+                    severity="error",
+                    row=first_idx,
+                    hint="Provide both *_R1* and *_R2* files for each paired-end sample.",
+                )
+            )
+
+    return issues
+
+
+def check_dates_iso8601(
+    df: pd.DataFrame,
+    date_cols: List[str],
+) -> List[WarningItem]:
+    """
+    Spec: type == 'dates_are_iso8601'
+          spec['columns'] = ["collection_date", ...]
+
+    Rule: each non-empty value in those columns must match YYYY-MM-DD.
+    Violations are WARN, not FAIL.
+    """
+    issues: List[WarningItem] = []
+    iso_pat = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+    for col in date_cols:
+        if col not in df.columns:
+            continue
+        for idx, raw in df[col].items():
+            val = str(raw).strip()
+            if val == "":
+                continue
+            if not iso_pat.match(val):
+                issues.append(
+                    WarningItem(
+                        column=col,
+                        kind="invalid_iso8601_date",
+                        message=f"Value '{val}' in {col} is not ISO8601 (YYYY-MM-DD).",
+                        severity="warning",
+                        row=int(idx),
+                        hint="Use format YYYY-MM-DD, e.g. 2025-10-02.",
+                    )
+                )
+    return issues
+
+
+def check_processed_data_present(
+    files_df: pd.DataFrame,
+    *,
+    samples_key: str,
+    raw_file_glob: str,
+    processed_globs: List[str],
+) -> List[WarningItem]:
+    """
+    Spec: type == 'processed_data_present'
+          spec['samples_key']                e.g. "sample_id"
+          spec['raw_file_glob']              e.g. ".fastq"
+          spec['processed_glob_candidates']  e.g. [".counts.", ".quant."]
+
+    Rule: for each sample, if we see raw FASTQs, do we also see at least
+    one processed/quant file? If not, WARN.
+    """
+    issues: List[WarningItem] = []
+
+    if samples_key not in files_df.columns:
+        return issues
+
+    def is_raw(fn: str) -> bool:
+        return raw_file_glob in fn
+
+    def is_processed(fn: str) -> bool:
+        return any(pat in fn for pat in processed_globs)
+
+    for sid, group in files_df.groupby(samples_key):
+        fns = group["filename"].astype(str).tolist() if "filename" in group.columns else []
+
+        has_raw = any(is_raw(fn) for fn in fns)
+        has_proc = any(is_processed(fn) for fn in fns)
+
+        if has_raw and not has_proc:
+            first_idx = int(group.index[0]) if len(group.index) > 0 else None
+            issues.append(
+                WarningItem(
+                    column="filename",
+                    kind="no_processed_files",
+                    message=f"Sample '{sid}' has raw data but no processed/quant files.",
+                    severity="warning",
+                    row=first_idx,
+                    hint="Include at least one processed output (e.g. counts matrix).",
+                )
+            )
+
+    return issues

--- a/fairy/ui/tabs/export_validate.py
+++ b/fairy/ui/tabs/export_validate.py
@@ -9,12 +9,43 @@ import pandas as pd
 import streamlit as st
 
 from fairy.ui.shared.context import ProjectCtx
+from fairy.core.storage import update_project_timestamp
+from fairy.core.services.validator import run_rulepack
+
+# this import is from your current code
 from fairy.validation.process_csv import process_csv
 from fairy.core.services.report_writer import write_report
-from fairy.core.storage import update_project_timestamp
+
+FAIRY_VERSION = "0.1.0"
+
+# ----------------------------
+# Helpers
+# ----------------------------
+
+def _read_manifest(uploaded_file):
+    """
+    Try TSV first, then CSV fallback.
+    Returns a DataFrame[str] ("" for blanks) or None if unreadable.
+    """
+    if uploaded_file is None:
+        return None
+
+    try:
+        df = pd.read_csv(uploaded_file, sep="\t", dtype=str).fillna("")
+        return df
+    except Exception:
+        pass
+
+    try:
+        uploaded_file.seek(0)
+        df = pd.read_csv(uploaded_file, sep=",", dtype=str).fillna("")
+        return df
+    except Exception:
+        return None
 
 
 def _build_metadata(df: pd.DataFrame, filename: str) -> Dict[str, Any]:
+    # This is from your original code
     return {
         "dataset_id": {"filename": filename},
         "run_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -22,18 +53,353 @@ def _build_metadata(df: pd.DataFrame, filename: str) -> Dict[str, Any]:
         "columns": [str(c) for c in list(df.columns)[:10]],
     }
 
-def render_export_validate_tab(ctx: ProjectCtx) -> None:
-    st.subheader("Export & Validate")
 
+# ----------------------------
+# Flow 1: RNA-seq GEO rulepack preflight
+# (This is the new "serious" validator)
+# ----------------------------
+
+def _render_rnaseq_preflight(ctx: ProjectCtx) -> None:
+    import streamlit as st  # make sure we have st in scope here
+
+    st.markdown(
+        """
+        **GEO bulk RNA-seq preflight**
+
+        Upload:
+        - `samples.tsv` (one row per biological sample)
+        - `files.tsv` (FASTQs / processed outputs for each sample_id)
+
+        FAIRy will:
+        - decide if you're submission_ready (✅ / ❌),
+        - show FAIL (blocking) vs WARN (non-blocking),
+        - tell you how to fix each problem,
+        - produce an attestation JSON you can save.
+        """
+    )
+
+    # lil badge instead of st.info so it doesn't collapse on rerun
+    st.markdown(
+        """
+        <div style="
+            background-color:#1d2f40;
+            border:1px solid #2f445a;
+            border-radius:4px;
+            padding:0.5rem 0.75rem;
+            color:#cfe9ff;
+            font-size:0.9rem;
+            display:inline-block;
+            font-weight:500;
+            margin-bottom:1rem;
+        ">
+        Rulepack: GEO-SEQ-BULK@0.1.0
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    col_left, col_right = st.columns(2)
+    with col_left:
+        samples_file = st.file_uploader(
+            "samples.tsv",
+            type=["tsv", "txt", "csv"],
+            help="Sample metadata. Must include sample_id and biological context (tissue / cell_line / cell_type).",
+            key="pre_samples",
+        )
+    with col_right:
+        files_file = st.file_uploader(
+            "files.tsv",
+            type=["tsv", "txt", "csv"],
+            help="File manifest linking FASTQs and processed outputs to each sample_id.",
+            key="pre_files",
+        )
+
+    run_btn = st.button(
+        "Run FAIRy Preflight ✅",
+        type="primary",
+        key="pre_run",
+    )
+
+    # We'll store the latest run's output in session_state so it survives rerun
+    result_key = f"preflight_result_{ctx.id}"
+    last_report = st.session_state.get(result_key)
+
+    # If the user clicked the button this run, compute a fresh report
+    if run_btn:
+        if samples_file is None or files_file is None:
+            st.error("Please upload both `samples.tsv` and `files.tsv` before running FAIRy.")
+        else:
+            with st.spinner("Validating…"):
+                # parse manifests
+                samples_df = _read_manifest(samples_file)
+                files_df = _read_manifest(files_file)
+
+                if samples_df is None:
+                    st.error("Could not parse `samples.tsv` as TSV or CSV.")
+                    samples_df = None
+                if files_df is None:
+                    st.error("Could not parse `files.tsv` as TSV or CSV.")
+                    files_df = None
+
+                if samples_df is not None and files_df is not None:
+                    # write temp copies so run_rulepack() can read from disk
+                    tmp_dir = ctx.proj_root / ".preflight_tmp"
+                    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+                    tmp_samples_path = tmp_dir / "samples.tmp.tsv"
+                    tmp_files_path = tmp_dir / "files.tmp.tsv"
+                    samples_df.to_csv(tmp_samples_path, sep="\t", index=False)
+                    files_df.to_csv(tmp_files_path, sep="\t", index=False)
+
+                    rulepack_path = Path("fairy/rulepacks/GEO-SEQ-BULK/v0_1_0.json")
+
+                    report = run_rulepack(
+                        rulepack_path=rulepack_path,
+                        samples_path=tmp_samples_path,
+                        files_path=tmp_files_path,
+                        fairy_version=FAIRY_VERSION,
+                    )
+
+                    # cache the report + the preview dfs so we can show after rerun
+                    st.session_state[result_key] = {
+                        "report": report,
+                        "samples_preview": samples_df.head(20),
+                        "files_preview": files_df.head(20),
+                    }
+
+                    # also append to project history right now
+                    att = report["attestation"]
+                    export_record = {
+                        "id": f"preflight_{int(datetime.now(timezone.utc).timestamp())}",
+                        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                        "summary": (
+                            f"submission_ready={att['submission_ready']}, "
+                            f"FAIL={att['fail_count']}, WARN={att['warn_count']}"
+                        ),
+                        "files": {
+                            "report_json": report,
+                        },
+                    }
+                    ctx.project.setdefault("exports", []).append(export_record)
+                    update_project_timestamp(ctx.project)
+                    ctx.save_and_refresh(ctx.projects)
+                    # ctx.save_and_refresh triggers st.rerun()
+                    # After rerun, run_btn will be False but session_state[result_key] will exist.
+
+        # After clicking, we don't render below in THIS run because st.rerun() will happen.
+        # Just return now.
+        return
+
+    # If we reach here, either:
+    # - user hasn't run yet this session, OR
+    # - we've rerun after a successful run, so result is in session_state
+    latest = st.session_state.get(result_key)
+    if not latest:
+        # nothing run yet -> show previous exports table (history) and bail
+        if ctx.project.get("exports"):
+            st.markdown("---")
+            st.markdown("Previous validations / attestations")
+            st.write(
+                pd.DataFrame(ctx.project["exports"])[
+                    ["id", "created_at", "summary"]
+                ]
+            )
+        return
+
+    # ----- We have a cached result: show full rich output -----
+
+    report = latest["report"]
+    att = report["attestation"]
+    findings = report["findings"]
+
+    # 1. Submission readiness banner
+    ready_str = "✅ Submission READY" if att["submission_ready"] else "❌ Submission NOT READY"
+
+    st.markdown(
+        f"""
+        <div style="
+            background-color:#24384a;
+            border:1px solid #3a5068;
+            border-radius:4px;
+            padding:0.75rem 1rem;
+            color:#ffffff;
+            font-weight:600;
+            margin-top:1.5rem;
+            margin-bottom:0.5rem;
+        ">
+        {ready_str}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(
+        f"""
+        <div style="
+            background-color:#1f3a1f;
+            border:1px solid #395239;
+            border-radius:4px;
+            padding:0.5rem 1rem;
+            color:#d8ffd8;
+            font-size:0.9rem;
+            margin-bottom:1rem;
+        ">
+        FAIL findings: <b>{att['fail_count']}</b> &nbsp;|&nbsp;
+        WARN findings: <b>{att['warn_count']}</b><br/>
+        Rulepack: <code>{att['rulepack_id']}@{att['rulepack_version']}</code><br/>
+        FAIRy: <code>{att['fairy_version']}</code><br/>
+        Run at (UTC): {att['run_at_utc']}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    # 2. Preview inputs
+    st.markdown("#### Preview (first 20 rows)")
+    with st.expander("samples.tsv preview", expanded=False):
+        st.dataframe(latest["samples_preview"], use_container_width=True)
+    with st.expander("files.tsv preview", expanded=False):
+        st.dataframe(latest["files_preview"], use_container_width=True)
+
+    # 3. Summary banners for FAIL / WARN
+    fail_count = att["fail_count"]
+    warn_count = att["warn_count"]
+
+    if fail_count > 0:
+        st.markdown(
+            f"""
+            <div style="
+                background-color:#553333;
+                border:1px solid #aa5555;
+                border-radius:4px;
+                padding:0.75rem 1rem;
+                color:#ffdada;
+                font-weight:500;
+                margin-top:1rem;
+            ">
+            {fail_count} blocking FAIL finding(s). You must fix these before submission.
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    if warn_count > 0:
+        st.markdown(
+            f"""
+            <div style="
+                background-color:#555533;
+                border:1px solid #aaaa55;
+                border-radius:4px;
+                padding:0.75rem 1rem;
+                color:#fff8c0;
+                font-weight:500;
+                margin-top:0.5rem;
+            ">
+            {warn_count} WARN finding(s). These may pass submission, but should be cleaned up.
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    if fail_count == 0 and warn_count == 0:
+        st.markdown(
+            """
+            <div style="
+                background-color:#1f3a1f;
+                border:1px solid #395239;
+                border-radius:4px;
+                padding:0.75rem 1rem;
+                color:#d8ffd8;
+                font-weight:500;
+                margin-top:1rem;
+            ">
+            No FAIL or WARN findings. Looks good for submission 🎉
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    # 4. Findings table + detail expanders
+    st.markdown("#### Findings")
+    if len(findings) == 0:
+        st.success("No issues to report.")
+    else:
+        flat_rows: List[Dict[str, Any]] = []
+        for f in findings:
+            flat_rows.append({
+                "Severity": f["severity"],
+                "Code": f["code"],
+                "Where": f["where"],
+                "Why this matters": f["why"],
+                "How to fix": f["how_to_fix"],
+            })
+        st.dataframe(pd.DataFrame(flat_rows), use_container_width=True)
+
+        st.markdown("#### Details per finding")
+        for f in findings:
+            header = f"[{f['severity']}] {f['code']} @ {f['where']}"
+            with st.expander(header, expanded=False):
+                st.markdown(f"**Why this matters:** {f['why']}")
+                st.markdown(f"**How to fix:** {f['how_to_fix']}")
+                st.markdown("**Debug details:**")
+                st.json(f["details"])
+
+    # 5. FAIRy report JSON + download
+    st.markdown("#### FAIRy report JSON")
+    st.json(report)
+
+    st.download_button(
+        "Download FAIRy report.json",
+        data=json.dumps(report, indent=2).encode("utf-8"),
+        file_name="fairy_report.json",
+        mime="application/json",
+        key="pre_download",
+    )
+
+    # 6. History table (exports)
+    if ctx.project.get("exports"):
+        st.markdown("---")
+        st.markdown("Previous validations / attestations")
+        st.write(
+            pd.DataFrame(ctx.project["exports"])[
+                ["id", "created_at", "summary"]
+            ]
+        )
+
+# ----------------------------
+# Flow 2: Generic CSV checker
+# (This is your original code, mostly intact)
+# ----------------------------
+
+def _render_generic_csv_checker(ctx: ProjectCtx) -> None:
     MAX_MB = 200
+
+    st.markdown(
+        """
+        **Generic spreadsheet check (prototype)**
+
+        Upload any CSV/TSV. FAIRy will:
+        - parse it safely,
+        - show you the first rows,
+        - run lightweight checks,
+        - generate a minimal metadata.json you can download or save.
+
+        This is great for quick sanity checking before you commit to a repository.
+        """
+    )
+
     dry_run = st.toggle(
         "Dry-run (no files written)",
         value=True,
-        help="Preview/download only; no files saved, no history",
+        help="Preview/download only; no files saved to the project history.",
     )
-    upload = st.file_uploader("Upload a CSV to validate", type=["csv", "tsv", "txt"])
 
-    # --- Delimiter control state (per project) ---
+    upload = st.file_uploader(
+        "Upload a CSV/TSV to validate",
+        type=["csv", "tsv", "txt"]
+    )
+
+    # delimiter state per project
     delim_key = f"delim_{ctx.id}"
     if delim_key not in st.session_state:
         st.session_state[delim_key] = "auto"
@@ -43,8 +409,8 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
     old_sig = st.session_state.get(upload_sig_key)
     if upload is not None and new_sig != old_sig:
         st.session_state[upload_sig_key] = new_sig
-        st.session_state[delim_key] = "auto"          # reset delimiter when a new file arrives
-        st.session_state["min_meta_ok"] = False       # reset validation state
+        st.session_state[delim_key] = "auto"
+        st.session_state["min_meta_ok"] = False
         st.session_state["min_meta_payload"] = None
 
     if upload is not None:
@@ -60,15 +426,21 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
     st.session_state.setdefault("min_meta_ok", False)
 
     c1, c2 = st.columns([1, 1])
-    validate_btn = c1.button("Validate", type="primary", disabled=upload is None)
+    validate_btn = c1.button(
+        "Validate",
+        type="primary",
+        disabled=upload is None,
+        key="generic_validate_btn",
+    )
     export_btn = c2.button(
         "Export metadata.json",
         disabled=st.session_state.get("min_meta_ok") is not True,
+        key="generic_export_btn",
     )
 
     status = st.container()
 
-    # --- Validate (guardrails + friendly parse + preflight via process_csv) ---
+    # --- VALIDATE step (parse + process_csv) ---
     if validate_btn:
         if upload is None:
             st.warning("Please choose a file to validate.")
@@ -77,14 +449,14 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
         with status:
             st.info("Validating…")
 
-        # Size guardrail
+        # size guardrail
         size_mb = upload.size / (1024 * 1024)
         if size_mb > MAX_MB:
             st.session_state["min_meta_ok"] = False
             status.error(f"File too large ({size_mb:.1f} MB). Limit is {MAX_MB} MB.")
             st.stop()
 
-        # Parse with optional delimiter override (friendly errors)
+        # parse CSV/TSV with delimiter override
         try:
             if delim == "auto":
                 df = pd.read_csv(upload, low_memory=False)
@@ -110,12 +482,12 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
         with st.expander("Preview (first 20 rows)", expanded=False):
             st.dataframe(df.head(20), use_container_width=True)
 
-        # Persist the upload to project so downstream code has a real path
+        # Persist upload to disk for downstream uses (e.g. report_writer)
         ctx.proj_root.mkdir(parents=True, exist_ok=True)
         tmp_path = ctx.proj_root / (upload.name or "uploaded.csv")
         tmp_path.write_bytes(upload.getbuffer())
 
-        # FAIRy preflight
+        # FAIRy lightweight preflight
         meta_pre, _ = process_csv(str(tmp_path))
         warns = meta_pre.get("warnings", [])
         if warns:
@@ -125,17 +497,17 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
         else:
             st.info("No warnings produced by preflight checks.")
 
-        # Build minimal metadata.json (prototype)
+        # Build minimal metadata.json
         meta_payload = _build_metadata(df, tmp_path.name)
 
-        # Stash state for Export step
+        # Store state for Export step
         st.session_state["min_meta_ok"] = True
         st.session_state["min_meta_tmp_path"] = str(tmp_path)
         st.session_state["min_meta_filename"] = tmp_path.name
         st.session_state["min_meta_sha256"] = meta_pre.get("sha256", "0" * 64)
         st.session_state["min_meta_payload"] = meta_payload
 
-    # --- Export ---
+    # --- EXPORT step (write metadata.json + report) ---
     if export_btn:
         if st.session_state.get("min_meta_ok") is not True or not st.session_state.get("min_meta_payload"):
             st.warning("Validate a CSV successfully before exporting.")
@@ -144,23 +516,23 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
         meta = st.session_state["min_meta_payload"]
 
         if dry_run:
-            st.info("Dry-run enabled: no file written.")
+            st.info("Dry-run enabled: no file written to project.")
             st.download_button(
                 "Download preview (metadata.json)",
                 data=json.dumps(meta, indent=2).encode("utf-8"),
                 file_name="metadata.json",
                 mime="application/json",
+                key="generic_download_btn",
             )
             with st.expander("Preview JSON"):
                 st.code(json.dumps(meta, indent=2), language="json")
             return
 
-        # 1) Write metadata.json
+        # Actually write metadata + report into the project
         ctx.out_dir.mkdir(parents=True, exist_ok=True)
         meta_path = ctx.out_dir / "metadata.json"
         meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
 
-        # 2) Write schema-validated report.json (v0.1) to project_dir/out
         report_path: Optional[Path] = None
         try:
             report_path = write_report(
@@ -171,7 +543,7 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
                     "n_rows": int(meta["shape"]["n_rows"]),
                     "n_cols": int(meta["shape"]["n_cols"]),
                     "fields_validated": meta.get("columns", []),
-                    "warnings": [],  # can feed process_csv warnings later
+                    "warnings": [],  # you could plumb in warns later
                 },
                 rulepacks=[],
                 provenance={"license": None, "source_url": None, "notes": None},
@@ -181,8 +553,7 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
         except Exception as e:
             st.warning(f"Report writer skipped due to error: {e}")
 
-        # 3) Record export entry in project
-        p = ctx.project
+        # Log this export in the project
         export_record = {
             "id": f"exp_{int(datetime.now(timezone.utc).timestamp())}",
             "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -192,13 +563,27 @@ def render_export_validate_tab(ctx: ProjectCtx) -> None:
                 "report": str(report_path.resolve()) if report_path else None,
             },
         }
-        p.setdefault("exports", []).append(export_record)
-        update_project_timestamp(p)
+        ctx.project.setdefault("exports", []).append(export_record)
+        update_project_timestamp(ctx.project)
         ctx.save_and_refresh(ctx.projects)
 
-        st.success(f"Export complete: {meta_path}")
-        st.code(json.dumps(meta, indent=2), language="json")
-
-    # Existing exports table
+    # show previous exports table (history)
     if ctx.project.get("exports"):
+        st.markdown("---")
         st.write(pd.DataFrame(ctx.project["exports"])[["id", "created_at", "summary"]])
+
+
+# ----------------------------
+# Router: decide which flow to show
+# ----------------------------
+
+def render_export_validate_tab(ctx: ProjectCtx) -> None:
+    project_type = ctx.project.get("type", "RNA-seq")
+
+    st.subheader("Export & Validate")
+    st.caption(f"Project type: {project_type}")
+
+    if project_type == "RNA-seq":
+        _render_rnaseq_preflight(ctx)
+    else:
+        _render_generic_csv_checker(ctx)


### PR DESCRIPTION
…, attestation)

- Add run_rulepack() wiring into Export & Validate tab
- Cache latest preflight results in session_state so UI survives rerun
- Show submission_ready ✅/❌, FAIL/WARN counts, per-finding how_to_fix
- Append each run to project exports[] as an attestation history
- Restore validate_csv() path so generic CSV validator still works
- Add validation_api registry/types for validators
- Add demos/bulk_demo with samples.tsv/files.tsv for GEO